### PR TITLE
BUGFIX: Permission Denied when replacing a symlink with a file

### DIFF
--- a/egginst/_zipfile.py
+++ b/egginst/_zipfile.py
@@ -90,6 +90,11 @@ class ZipFile(zipfile.ZipFile):
         if is_zipinfo_symlink(member):
             return self._extract_symlink(member, targetpath, pwd)
         else:
+            # Check if we are replacing a symlink with a file
+            # and if so, remove the link first
+            if os.path.islink(targetpath):
+                os.unlink(targetpath)
+
             source = self.open(member, pwd=pwd)
             try:
                 with open(targetpath, "wb") as target:


### PR DESCRIPTION
When replacing a symlink object with a file object, enstaller will fail with 'Permission Denied' if the link target is in the system Canopy installation. This change checks if the target for a file write is a symlink and unlinks it if necessary.