### PR TITLE
Fix to_config_dict implementation.

### DIFF
--- a/enstaller/auth/_impl.py
+++ b/enstaller/auth/_impl.py
@@ -193,7 +193,7 @@ class APITokenAuth(IAuth):
             fp.write(data)
 
     def to_config_dict(self):
-        return {"kind": "token", "api_token": self.api_token}
+        return {"kind": "token", "api_token": self._api_token}
 
     @property
     def cant_login_message(self):

--- a/enstaller/auth/tests/test__impl.py
+++ b/enstaller/auth/tests/test__impl.py
@@ -232,3 +232,11 @@ class TestAPITokenAuth(unittest.TestCase):
 
         # Then
         self.assertEqual(auth.cant_login_message, r_message)
+
+    def test_to_config_dict(self):
+        # When
+        auth = APITokenAuth("bad robot")
+
+        # Then
+        self.assertEqual(auth.to_config_dict(),
+                         {"kind": "token", "api_token": "bad robot"})


### PR DESCRIPTION
There was a typo in the `APITokenAuth.to_config_dict` method which rendered it non-functional.  This PR fixes it.